### PR TITLE
Use CloudFlare Queues for long task like fetching response from openai

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,24 +1,18 @@
 import { Hono } from 'hono'
 import { Env } from './types'
-import { useOpenai, useOctokit, Middleware } from './middleware'
 import { handleGithubIssueWebhook } from './services'
 import type { WebhookEvent } from '@octokit/webhooks-types'
+import OpenAI from 'openai'
+import { Octokit } from '@octokit/rest'
 
 const app = new Hono<Env>()
 
-app.use(useOctokit)
-app.use(useOpenai)
-
 app.post('/webhook', async (c) => {
   const payload = (await c.req.json()) as WebhookEvent
-  const { openai, octokit } = c.var as Middleware
 
   try {
-    // Enqueue the long-running task
     await c.env.QUEUE.send({
-      payload,
-      octokit,
-      openai
+      payload
     })
 
     return c.text('Request enqueued', 202) // Accepted
@@ -28,17 +22,28 @@ app.post('/webhook', async (c) => {
   }
 })
 
-// Consumer for the queue
+const getOpenai = (token: string) =>
+  new OpenAI({
+    baseURL: 'https://openrouter.ai/api/v1',
+    apiKey: token,
+    defaultHeaders: {
+      'X-Title': 'Repo helper'
+    }
+  })
+
+const useOctokit = (token: string) =>
+  new Octokit({
+    auth: token
+  })
+
 export const queue = {
-  async queue(batch: MessageBatch<any>, env: Env): Promise<void> {
+  async queue(batch: any, env: Env): Promise<void> {
+    const openai = getOpenai(env.OPENAI_API_KEY)
+    const octokit = useOctokit(env.GITHUB_TOKEN)
     for (const message of batch.messages) {
       try {
-        const { payload, octokit, openai } = message.body
-        const result = await handleGithubIssueWebhook(
-          payload,
-          octokit,
-          openai
-        )
+        const { payload } = message.body
+        const result = await handleGithubIssueWebhook(payload, octokit, openai)
         console.log(
           `Processed message: ${message.id}, Result: ${result.message}`
         )
@@ -52,5 +57,5 @@ export const queue = {
 }
 export default {
   fetch: app.fetch,
-  queue
+  queue: queue.queue
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,16 +11,46 @@ app.use(useOpenai)
 
 app.post('/webhook', async (c) => {
   const payload = (await c.req.json()) as WebhookEvent
-
   const { openai, octokit } = c.var as Middleware
 
   try {
-    const result = await handleGithubIssueWebhook(payload, octokit, openai)
-    return c.text(result.message, result.status)
+    // Enqueue the long-running task
+    await c.env.QUEUE.send({
+      payload,
+      octokit,
+      openai
+    })
+
+    return c.text('Request enqueued', 202) // Accepted
   } catch (error) {
     console.error('Error in webhook handler:', error)
     return c.text('Internal server error', 500)
   }
 })
 
-export default app
+// Consumer for the queue
+export const queue = {
+  async queue(batch: MessageBatch<any>, env: Env): Promise<void> {
+    for (const message of batch.messages) {
+      try {
+        const { payload, octokit, openai } = message.body
+        const result = await handleGithubIssueWebhook(
+          payload,
+          octokit,
+          openai
+        )
+        console.log(
+          `Processed message: ${message.id}, Result: ${result.message}`
+        )
+        message.ack() // Acknowledge successful processing
+      } catch (error) {
+        console.error(`Error processing message ${message.id}:`, error)
+        message.retry() // Retry the message
+      }
+    }
+  }
+}
+export default {
+  fetch: app.fetch,
+  queue
+}

--- a/src/services/openaiService.ts
+++ b/src/services/openaiService.ts
@@ -51,7 +51,7 @@ export async function generateGptResponse(
     const options: ChatCompletionCreateParamsNonStreaming = {
       model: 'google/gemini-2.0-pro-exp-02-05:free',
       messages,
-      max_tokens: 30000
+      max_tokens: 50000
       //frequency_penalty: 1,
       //presence_penalty: 1
     }

--- a/src/types/issue.ts
+++ b/src/types/issue.ts
@@ -2,6 +2,6 @@ export type Env = {
   Bindings: {
     GITHUB_TOKEN: string
     OPENAI_API_KEY: string
-    QUEUE: Queue
+    QUEUE: any
   }
 }

--- a/src/types/issue.ts
+++ b/src/types/issue.ts
@@ -1,3 +1,7 @@
 export type Env = {
-  Bindings: { GITHUB_TOKEN: string; OPENAI_API_KEY: string }
+  Bindings: {
+    GITHUB_TOKEN: string
+    OPENAI_API_KEY: string
+    QUEUE: Queue
+  }
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -6,5 +6,22 @@
   "observability": {
     "enabled": true
   },
-  "compatibility_flags": ["nodejs_compat"]
+  "compatibility_flags": ["nodejs_compat"],
+  "queues": {
+    "producers": [
+      {
+        "queue": "repo-openai-jobs",
+        "binding": "QUEUE"
+      }
+    ],
+    "consumers": [
+      {
+        "queue": "repo-openai-jobs",
+        "max_batch_size": 10,
+        "max_batch_timeout": 30,
+        "max_retries": 10,
+        "dead_letter_queue": "my-queue-dlq"
+      }
+    ]
+  }
 }


### PR DESCRIPTION


 ```typescript
import { Hono } from 'hono'
import { Env } from './types'
import { useOpenai, useOctokit, Middleware } from './middleware'
import { handleGithubIssueWebhook } from './services'
import type { WebhookEvent } from '@octokit/webhooks-types'

const app = new Hono<Env>()

app.use(useOctokit)
app.use(useOpenai)

app.post('/webhook', async (c) => {
  const payload = (await c.req.json()) as WebhookEvent
  const { openai, octokit } = c.var as Middleware

  try {
    // Enqueue the long-running task
    await c.env.QUEUE.send({
      payload,
      octokit,
      openai
    })

    return c.text('Request enqueued', 202) // Accepted
  } catch (error) {
    console.error('Error in webhook handler:', error)
    return c.text('Internal server error', 500)
  }
})

// Consumer for the queue
export const queue = {
  async queue(batch: MessageBatch, env: Env): Promise<void> {
    for (const message of batch.messages) {
      try {
        const { payload, octokit, openai } = message.body
        const result = await handleGithubIssueWebhook(
          payload,
          octokit,
          openai
        )
        console.log(
          `Processed message: ${message.id}, Result: ${result.message}`
        )
        message.ack() // Acknowledge successful processing
      } catch (error) {
        console.error(`Error processing message ${message.id}:`, error)
        message.retry() // Retry the message
           }
    }
  }
}
export default {
  fetch: app.fetch,
    queue
}
```

```typescript
export type Env = {
  Bindings: {
    GITHUB_TOKEN: string
    OPENAI_API_KEY: string
    QUEUE: Queue
  }
}
```
